### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/next-dev-pipeline.yml
+++ b/.github/workflows/next-dev-pipeline.yml
@@ -235,7 +235,7 @@ jobs:
 #    steps:
 #      - uses: actions/checkout@v2
 #      - name: Publish to Dockerhub
-#        uses: elgohr/Publish-Docker-Github-Action@master
+#        uses: elgohr/Publish-Docker-Github-Action@v5
 #        with:
 #          path: '**/node_modules'
 #          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -272,7 +272,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: echo -e "export const COMMIT_ID = \"${GITHUB_SHA}\";\nexport const BUILD_TIME = \""`date -Iminutes -u`"\";" > app/buildInfo.js
       - name: Publish to Dockerhub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: stadtnavi/digitransit-ui
           username: ${{ secrets.DOCKER_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore